### PR TITLE
abort graphql execution on request close

### DIFF
--- a/index.js
+++ b/index.js
@@ -568,6 +568,7 @@ const plugin = fp(async function (app, opts) {
 
     const abortController = new AbortController()
     reply?.raw.on('close', () => {
+      console.log('aborted (log from Mercurius)')
       abortController.abort('Connection closed.')
     })
 

--- a/index.js
+++ b/index.js
@@ -566,13 +566,19 @@ const plugin = fp(async function (app, opts) {
       return maybeFormatErrors(execution, context)
     }
 
+    const abortController = new AbortController()
+    reply?.raw.on('close', () => {
+      abortController.abort('Connection closed.')
+    })
+
     const execution = await executeGraphql(opts.defer, {
       schema: modifiedSchema || fastifyGraphQl.schema,
       document: modifiedDocument || document,
       rootValue: root,
       contextValue: context,
       variableValues: variables,
-      operationName
+      operationName,
+      signal: abortController.signal
     })
 
     /* istanbul ignore next */

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://mercurius.dev",
   "peerDependencies": {
-    "graphql": "^17.0.0-alpha.2"
+    "graphql": "canary-pr-3791"
   },
   "devDependencies": {
     "@graphql-tools/merge": "^8.0.0",


### PR DESCRIPTION
This PR demonstrates a possible implementation of aborting the graphql execution on a graphql server side.

See the original [graphql-js PR](https://github.com/graphql/graphql-js/pull/3791) for more info and steps to test locally.
